### PR TITLE
Implements event-driven async for req_perform_promise()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Suggests:
     jose,
     jsonlite,
     knitr,
-    later,
+    later (>= 1.3.2.9001),
     paws.common,
     promises,
     rmarkdown,
@@ -54,3 +54,4 @@ Config/testthat/start-first: resp-stream, req-perform
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
+Remotes: r-lib/later

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr2 (development version)
 
+* `req_perform_promise()` upgraded to use event-driven async based on waiting efficiently on curl socket activity (#579).
+
 # httr2 1.0.6
 
 * Fix stochastic test failure, particularly on CRAN (#572)

--- a/R/req-promise.R
+++ b/R/req-promise.R
@@ -142,8 +142,7 @@ ensure_pool_poller <- function(pool, reject) {
             readfds = fds$reads,
             writefds = fds$writes,
             exceptfds = fds$exceptions,
-            timeout = fds$timeout,
-            loop = later::global_loop()
+            timeout = fds$timeout
           )
         } else {
           monitor$ending()

--- a/R/req-promise.R
+++ b/R/req-promise.R
@@ -9,6 +9,10 @@
 #' [promises package documentation](https://rstudio.github.io/promises/articles/promises_01_motivation.html)
 #' for more details on how to work with the resulting promise object.
 #'
+#' If using together with [later::with_temp_loop()] or other private event loops,
+#' a new curl pool made by [curl::new_pool()] should be created for requests made
+#' within the loop to ensure that only these requests are being polled by the loop.
+#'
 #' Like with [req_perform_parallel()], exercise caution when using this function;
 #' it's easy to pummel a server with many simultaneous requests. Also, not all servers
 #' can handle more than 1 request at a time, so the responses may still return

--- a/R/req-promise.R
+++ b/R/req-promise.R
@@ -69,6 +69,12 @@ req_perform_promise <- function(req,
   check_installed(c("promises", "later"))
   check_string(path, allow_null = TRUE)
 
+  if (missing(pool)) {
+    if (!identical(later::current_loop(), later::global_loop())) {
+      cli::cli_abort("When using {.code req_perform_promise()} within {.code later::with_temp_loop()}, {.arg x} must be provided.")
+    }
+  }
+
   promises::promise(
     function(resolve, reject) {
       perf <- PerformancePromise$new(

--- a/R/req-promise.R
+++ b/R/req-promise.R
@@ -75,7 +75,10 @@ req_perform_promise <- function(req,
 
   if (missing(pool)) {
     if (!identical(later::current_loop(), later::global_loop())) {
-      cli::cli_abort("When using {.code req_perform_promise()} within {.code later::with_temp_loop()}, {.arg pool} must be provided.")
+      cli::cli_abort(c(
+        "Must supply {.arg pool} when calling {.code later::with_temp_loop()}",
+        i = "Do you need {.code pool = curl::new_pool()}?"
+      ))
     }
   }
 

--- a/R/req-promise.R
+++ b/R/req-promise.R
@@ -71,7 +71,7 @@ req_perform_promise <- function(req,
 
   if (missing(pool)) {
     if (!identical(later::current_loop(), later::global_loop())) {
-      cli::cli_abort("When using {.code req_perform_promise()} within {.code later::with_temp_loop()}, {.arg x} must be provided.")
+      cli::cli_abort("When using {.code req_perform_promise()} within {.code later::with_temp_loop()}, {.arg pool} must be provided.")
     }
   }
 

--- a/R/req-promise.R
+++ b/R/req-promise.R
@@ -76,7 +76,7 @@ req_perform_promise <- function(req,
   if (missing(pool)) {
     if (!identical(later::current_loop(), later::global_loop())) {
       cli::cli_abort(c(
-        "Must supply {.arg pool} when calling {.code later::with_temp_loop()}",
+        "Must supply {.arg pool} when calling {.code later::with_temp_loop()}.",
         i = "Do you need {.code pool = curl::new_pool()}?"
       ))
     }

--- a/man/req_perform_promise.Rd
+++ b/man/req_perform_promise.Rd
@@ -29,6 +29,10 @@ is finished. See the
 \href{https://rstudio.github.io/promises/articles/promises_01_motivation.html}{promises package documentation}
 for more details on how to work with the resulting promise object.
 
+If using together with \code{\link[later:create_loop]{later::with_temp_loop()}} or other private event loops,
+a new curl pool made by \code{\link[curl:multi]{curl::new_pool()}} should be created for requests made
+within the loop to ensure that only these requests are being polled by the loop.
+
 Like with \code{\link[=req_perform_parallel]{req_perform_parallel()}}, exercise caution when using this function;
 it's easy to pummel a server with many simultaneous requests. Also, not all servers
 can handle more than 1 request at a time, so the responses may still return

--- a/tests/testthat/_snaps/req-promise.md
+++ b/tests/testthat/_snaps/req-promise.md
@@ -4,6 +4,6 @@
       p4 <- req_perform_promise(request_test("/get"))
     Condition
       Error in `req_perform_promise()`:
-      ! Must supply `pool` when calling `later::with_temp_loop()`
+      ! Must supply `pool` when calling `later::with_temp_loop()`.
       i Do you need `pool = curl::new_pool()`?
 

--- a/tests/testthat/_snaps/req-promise.md
+++ b/tests/testthat/_snaps/req-promise.md
@@ -1,0 +1,9 @@
+# req_perform_promise uses the default loop
+
+    Code
+      p4 <- req_perform_promise(request_test("/get"))
+    Condition
+      Error in `req_perform_promise()`:
+      ! Must supply `pool` when calling `later::with_temp_loop()`
+      i Do you need `pool = curl::new_pool()`?
+

--- a/tests/testthat/test-req-promise.R
+++ b/tests/testthat/test-req-promise.R
@@ -131,7 +131,7 @@ test_that("req_perform_promise uses the default loop", {
 
     # You can't create an async response in the temp loop without explicitly
     # specifying a pool
-    expect_error(p4 <- req_perform_promise(request_test("/get")))
+    expect_snapshot(p4 <- req_perform_promise(request_test("/get")), error = TRUE)
 
     # Like I said, you can create this, but it won't work until we get back
     # outside the temp loop

--- a/tests/testthat/test-req-promise.R
+++ b/tests/testthat/test-req-promise.R
@@ -2,16 +2,21 @@
 extract_promise <- function(promise, timeout = 30) {
   promise_value <- NULL
   error <- NULL
+  done <- FALSE
   promises::then(
     promise,
-    onFulfilled = function(value) promise_value <<- value,
+    onFulfilled = function(value) {
+      promise_value <<- value
+      done <<- TRUE
+    },
     onRejected = function(reason) {
       error <<- reason
+      done <<- TRUE
     }
   )
 
   start <- Sys.time()
-  while (!later::loop_empty()) {
+  while (!done) {
     if (difftime(Sys.time(), start, units = "secs") > timeout) {
       stop("Waited too long")
     }
@@ -88,17 +93,6 @@ test_that("both curl and HTTP errors in promises are rejected", {
     'inherits\\(pool, "curl_multi"\\) is not TRUE'
   )
 })
-
-test_that("req_perform_promise doesn't leave behind poller", {
-  skip_if_not(later::loop_empty(), "later::global_loop not empty when test started")
-  p <- req_perform_promise(request_test("/delay/:secs", secs = 0.25))
-  # Before promise is resolved, there should be an operation in our later loop
-  expect_false(later::loop_empty())
-  p_value <- extract_promise(p)
-  # But now that that our promise is resolved, we shouldn't still be polling the pool
-  expect_true(later::loop_empty())
-})
-
 
 test_that("req_perform_promise can use non-default pool", {
   custom_pool <- curl::new_pool()


### PR DESCRIPTION
Instead of polling at 0.1 second intervals, we use `later::later_fd()` to wait upon the curl sockets efficiently. This triggers only when one of the sockets has activity that requires processing.

`later::loop_empty()` takes into account these file descriptor waits, hence there are no changes to the existing tests.

Additional tests have been added by @jcheng5 for the use of private event loops, which require a new pool to be created inside the loop.